### PR TITLE
Add recipes for crafting dirt with dry grass

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -92,3 +92,19 @@ for i = 1, #sandstones do
 		end
 	end
 end
+
+
+-- 2019-12-22
+-- dirt with dry grass crafting
+
+minetest.register_craft({
+	output = "default:dry_dirt_with_dry_grass",
+	type = "shapeless",
+	recipe = {"default:dry_grass_1", "default:dry_dirt"},
+})
+
+minetest.register_craft({
+	output = "default:dirt_with_dry_grass",
+	type = "shapeless",
+	recipe = {"default:dry_grass_1", "default:dirt"},
+})


### PR DESCRIPTION
Since Minetest 5.1.0, it has not been possible to create dirt with dry grass, due to dry grass not spreading anymore. This makes landscaping with dry grass impossible, without using a jumpdrive to get it from somewhere else. (all other "special" dirt types can spread)