### PR TITLE
Make `default:junglegrass` obtainable by mulching

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -9,7 +9,8 @@ globals = {
 	"unified_inventory",
 	"telemosaic",
 	"gravity_manager",
-	"spacecannon"
+	"spacecannon",
+	"bonemeal"
 }
 
 read_globals = {

--- a/bonemeal.lua
+++ b/bonemeal.lua
@@ -1,0 +1,7 @@
+
+-- makes junglegrass obtainable by mulching
+-- junglegrass is used to make many nodes, such as moreblocks:clean_glass
+bonemeal:add_deco({
+	{ "default:dirt_with_rainforest_litter",
+		{"default:junglegrass", "", ""}, {} }
+})

--- a/init.lua
+++ b/init.lua
@@ -140,6 +140,10 @@ if minetest.get_modpath("scifi_nodes") then
 	dofile(MP.."/scifi_override.lua")
 end
 
+if minetest.get_modpath("bonemeal") then
+	dofile(MP.."/bonemeal.lua")
+end
+
 if minetest.settings:get_bool("enable_integration_test") then
 	dofile(MP.."/integration_test.lua")
 end

--- a/mod.conf
+++ b/mod.conf
@@ -31,4 +31,5 @@ fancy_vend,
 mypaths,
 moreblocks,
 bakedclay,
+bonemeal,
 """


### PR DESCRIPTION
Brought to my attention by @int-ua, `default:junglegrass` is used in multiple recipes, including a step in crafting `moreblocks:clean_glass`, but is hard to obtain in larger quantities.   