### PR TITLE
Let's make bamboo trunks climbable

### DIFF
--- a/plant_overrides.lua
+++ b/plant_overrides.lua
@@ -1,0 +1,6 @@
+-- This file contains plantlife-related overrides
+
+-- Players should be able to climb bamboo trunks
+minetest.override_item("bamboo:trunk", {
+	climbable = true
+})


### PR DESCRIPTION
Trunks look sturdy, but players can't climb those. Let's fix that.