### PR TITLE
Bugfix for climbable bamboo trunks

### DIFF
--- a/plant_overrides.lua
+++ b/plant_overrides.lua
@@ -2,5 +2,6 @@
 
 -- Players should be able to climb bamboo trunks
 minetest.override_item("bamboo:trunk", {
+	walkable = true,
 	climbable = true
 })


### PR DESCRIPTION
I found out climbing bamboo trunks does not work. I should've done more testing.

As @OgelGames said, `walkable` flag is required. IMO it's weird to make player noclip through trunks, but I don't know an alternative if there's one.

P.S.: it might be easier to reject this PR and update [CoolTrees](https://github.com/runsy/cool_trees/blob/master/bamboo/init.lua). Currently, CoolTrees bamboo is walkable (line `151`).

P.P.S.: requested climbable bamboos in CoolTrees, too. :-)