### PR TITLE
remove amun planetary system

### DIFF
--- a/planets.lua
+++ b/planets.lua
@@ -20,36 +20,6 @@ planetoidgen.register_planet({
   radius = 250, type = "class-m", name = "Eula's planet", airshell = true
 })
 
--- amun system
-planetoidgen.register_planet({
-  pos = { x = 10000, y = 9700, z = 15000 },
-  radius = 250, type = "sun", name = "system-1 sun"
-})
-planetoidgen.register_planet({
-  pos = { x = 10000, y = 9700, z = 15600 },
-  radius = 100, type = "class-m", name = "system-1 top", airshell = true
-})
-planetoidgen.register_planet({
-  pos = { x = 10520, y = 9700, z = 15300 },
-  radius = 100, type = "class-n", name = "system-1 top-right stone"
-})
-planetoidgen.register_planet({
-  pos = { x = 10520, y = 9700, z = 14700 },
-  radius = 100, type = "class-m", name = "system-1 bottom-right", airshell = true
-})
-planetoidgen.register_planet({
-  pos = { x = 10000, y = 9700, z = 14400 },
-  radius = 100, type = "class-p", name = "system-1 bottom ice", airshell = true
-})
-planetoidgen.register_planet({
-  pos = { x = 9480, y = 9700, z = 14700 },
-  radius = 100, type = "class-m", name = "system-1 bottom-left", airshell = true
-})
-planetoidgen.register_planet({
-  pos = { x = 9480, y = 9700, z = 15300 },
-  radius = 100, type = "class-h", name = "system-1 top-left desert", airshell = true
-})
-
 -- unnamed system
 planetoidgen.register_planet({
   pos = { x = 9000, y = 9500, z = 5000 },


### PR DESCRIPTION
Removes the planet registrations for the `amun` system (top right, space layer)
This should make space for future planetary systems and whatnot.

Should be merged around the time the cleanup-query has done its job and _before_ the web-map gets re-rendered
See "Large scale removals" here https://github.com/pandorabox-io/pandorabox.io/issues/528

There is nothing really of value there, no one else built there but me (except one travelnet box from `int`).
Also: there are some tunnels made in creative ("admin"-player) that i'm not really proud of...

## TODO

* [ ] Re-check if no-one else built there
* [ ] Check and remove areas