### PR TITLE
add gravel-stonebrick

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -37,5 +37,5 @@ read_globals = {
 	"advtrains",
 	"letters", "player_monoids",
 	"pipeworks", "planetoidgen",
-	"xban", "moreblocks", "stairsplus"
+	"xban", "stairsplus"
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -37,5 +37,5 @@ read_globals = {
 	"advtrains",
 	"letters", "player_monoids",
 	"pipeworks", "planetoidgen",
-	"xban"
+	"xban", "moreblocks", "stairsplus"
 }

--- a/init.lua
+++ b/init.lua
@@ -214,3 +214,8 @@ end
 if minetest.get_modpath("digistuff") then
 	dofile(MP .. "/digi_copier_fixer.lua")
 end
+
+-- custom staursplus/moreblocks nodes
+if minetest.get_modpath("moreblocks") then
+	dofile(MP .. "/moreblocks.lua")
+end

--- a/moreblocks.lua
+++ b/moreblocks.lua
@@ -1,0 +1,27 @@
+local sound_gravel = default.node_sound_gravel_defaults()
+
+-- sanity checks
+assert(sound_gravel)
+
+-- custom node table
+local nodes = {
+	["gravel_stonebrick"] = {
+		description = "Gravel on Stonebrick",
+		tiles = {
+			"default_gravel.png",
+			"default_stone_brick.png",
+			"default_gravel.png^[lowpart:50:default_stone_brick.png",
+			"default_gravel.png^[lowpart:50:default_stone_brick.png",
+			"default_gravel.png^[lowpart:50:default_stone_brick.png",
+			"default_gravel.png^[lowpart:50:default_stone_brick.png"
+		},
+		no_stairs = true,
+		groups = {cracky = 3},
+		sounds = sound_gravel,
+	}
+}
+
+for name, def in pairs(nodes) do
+	minetest.register_node(":moreblocks:" .. name, def)
+	stairsplus:register_all("moreblocks", name,  "moreblocks:" .. name, def)
+end

--- a/moreblocks.lua
+++ b/moreblocks.lua
@@ -1,27 +1,31 @@
-local sound_gravel = default.node_sound_gravel_defaults()
 
--- sanity checks
-assert(sound_gravel)
+-- half gravel, half stonebrick
+minetest.register_node(":moreblocks:gravel_stonebrick", {
+	description = "Gravel on Stonebrick",
+	tiles = {
+		"default_gravel.png",
+		"default_stone_brick.png",
+		"default_gravel.png^[lowpart:50:default_stone_brick.png",
+		"default_gravel.png^[lowpart:50:default_stone_brick.png",
+		"default_gravel.png^[lowpart:50:default_stone_brick.png",
+		"default_gravel.png^[lowpart:50:default_stone_brick.png"
+	},
+	no_stairs = true,
+	groups = {cracky = 3},
+	sounds = default.node_sound_gravel_defaults()
+})
 
--- custom node table
-local nodes = {
-	["gravel_stonebrick"] = {
-		description = "Gravel on Stonebrick",
-		tiles = {
-			"default_gravel.png",
-			"default_stone_brick.png",
-			"default_gravel.png^[lowpart:50:default_stone_brick.png",
-			"default_gravel.png^[lowpart:50:default_stone_brick.png",
-			"default_gravel.png^[lowpart:50:default_stone_brick.png",
-			"default_gravel.png^[lowpart:50:default_stone_brick.png"
-		},
-		no_stairs = true,
-		groups = {cracky = 3},
-		sounds = sound_gravel,
-	}
-}
+stairsplus:register_all(
+	"moreblocks",
+	"gravel_stonebrick",
+	"moreblocks:gravel_stonebrick",
+	minetest.registered_nodes["moreblocks:gravel_stonebrick"]
+)
 
-for name, def in pairs(nodes) do
-	minetest.register_node(":moreblocks:" .. name, def)
-	stairsplus:register_all("moreblocks", name,  "moreblocks:" .. name, def)
-end
+minetest.register_craft({
+    output = "moreblocks:gravel_stonebrick 4",
+    recipe = {
+        {"default:gravel", "default:gravel"},
+        {"default:stonebrick", "default:stonebrick"},
+    }
+})


### PR DESCRIPTION
This PR adds a half-gravel, half-stonebrick node with support for the table-saw

@wsor4035
```
could we get a node that is gravel on top and a solid base on bottem like linux forks has? also, ability to slice it into 3 piece slopes to match the track slope
https://git.bananach.space/moreblocks.git/tree/nodes.lua#n634
```

![screenshot_20210213_114027](https://user-images.githubusercontent.com/39065740/107848007-a7385e80-6df0-11eb-97bd-3d6addf84798.png)

## TODO

* [x] recipe for `moreblocks:gravel_stonebrick`

## Stats

* Additional nodes: 49 (current node-count: 22051, see https://monitoring.minetest.land/d/QcXQ62fZk/registered-counts)
* Additional lag: none :yum: