### PR TITLE
Add craft recipes for `digilines:rtc` and `digilines:lightsensor`

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -112,7 +112,7 @@ minetest.register_craft({
 
 
 
--- 2020-20-21
+-- 2020-10-21
 -- cookable tools and armor (91 recipes total)
 
 local cookable_items = {

--- a/recipes.lua
+++ b/recipes.lua
@@ -224,3 +224,23 @@ if minetest.get_modpath("pipeworks") then
 		})
 	end
 end
+
+-- craft recipes for digilines rtc and lightsensor
+if minetest.get_modpath("digilines") and minetest.get_modpath("basic_materials") then
+	minetest.register_craft({
+		output = "digilines:rtc",
+		recipe = {
+			{"basic_materials:plastic_sheet", "default:mese_crystal_fragment", "basic_materials:plastic_sheet"},
+			{"dye:black", "basic_materials:ic", "dye:black"},
+			{"basic_materials:plastic_sheet", "digilines:wire_std_00000000", "basic_materials:plastic_sheet"}
+		}
+	})
+	minetest.register_craft({
+		output = "digilines:lightsensor",
+		recipe = {
+			{"basic_materials:plastic_sheet", "default:glass", "basic_materials:plastic_sheet"},
+			{"basic_materials:plastic_sheet", "basic_materials:ic", "basic_materials:plastic_sheet"},
+			{"basic_materials:plastic_sheet", "digilines:wire_std_00000000", "basic_materials:plastic_sheet"}
+		}
+	})
+end

--- a/recipes.lua
+++ b/recipes.lua
@@ -225,8 +225,9 @@ if minetest.get_modpath("pipeworks") then
 	end
 end
 
--- craft recipes for digilines rtc and lightsensor
+-- custom craft recipes for digilines rtc and lightsensor
 if minetest.get_modpath("digilines") and minetest.get_modpath("basic_materials") then
+	minetest.clear_craft({output = "digilines:rtc"})
 	minetest.register_craft({
 		output = "digilines:rtc",
 		recipe = {
@@ -235,6 +236,7 @@ if minetest.get_modpath("digilines") and minetest.get_modpath("basic_materials")
 			{"basic_materials:plastic_sheet", "digilines:wire_std_00000000", "basic_materials:plastic_sheet"}
 		}
 	})
+	minetest.clear_craft({output = "digilines:lightsensor"})
 	minetest.register_craft({
 		output = "digilines:lightsensor",
 		recipe = {


### PR DESCRIPTION
Both of these nodes should have craft recipes, as they are not "game-breaking" nodes; this PR adds recipes for them:

![rtc](https://user-images.githubusercontent.com/48543043/117401487-04533480-af48-11eb-833e-c324ee544e54.png)
![lightsensor](https://user-images.githubusercontent.com/48543043/117401493-074e2500-af48-11eb-90a0-60128a7f4ac1.png)

@S-S-X @SwissalpS @FeXoR-o-Illuria any suggestions/objections?

@BuckarooBanzay the admin vendor for `digilines:rtc` can be removed after this ;)