### PR TITLE
advtrains debug messages to advtrains channel

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -17,7 +17,9 @@ globals = {
 	"mobs",
 	"unpack",
 	"farming",
-	"protector"
+	"protector",
+	-- Advtrains global functions
+	"atdebug", "atwarn"
 }
 
 read_globals = {

--- a/beerchat.lua
+++ b/beerchat.lua
@@ -4,3 +4,18 @@ beerchat.register_callback("before_join", function(name, channel)
                 return false
         end
 end)
+
+atwarn = function(t, ...)
+	local text = advtrains.print_concat_table({t, ...})
+	minetest.log("warning", "[advtrains]"..text)
+	--minetest.chat_send_all("[advtrains] -!- "..text)
+	beerchat.send_on_channel("[advtrains] -!- ", "advtrains", text)
+end
+
+--ONLY use this function for temporary debugging. for consistent debug prints use atprint
+atdebug = function(t, ...)
+	local text = advtrains.print_concat_table({t, ...})
+	minetest.log("action", "[advtrains]"..text)
+	--minetest.chat_send_all("[advtrains]"..text)
+	beerchat.send_on_channel("[advtrains]", "advtrains", text)
+end

--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,7 @@
 name = pandorabox_custom
 depends = default, sethome, farming
 optional_depends = """
+advtrains,
 advtrains_platform,
 bakedclay,
 bamboo,


### PR DESCRIPTION
Did not test at all but this should redirect advtrains debug messages to #advtrains chat channel instead of spamming all players.

Would be good to test first.