### PR TITLE
ehlphabet stickers

### DIFF
--- a/ehlphabet.lua
+++ b/ehlphabet.lua
@@ -1,0 +1,65 @@
+if not minetest.get_modpath('ehlphabet') then return end
+
+-- stickers of mandarin characters
+minetest.register_craft({
+    output = "ehlphabet:231140_sticker 4",
+    recipe = {
+        {"", "", ""},
+        {"ehlphabet:78_sticker", "", ""},
+        {"ehlphabet:69_sticker", "ehlphabet:75_sticker", "ehlphabet:79_sticker"}
+    }
+})
+
+minetest.register_craft({
+    output = "ehlphabet:229140_sticker 5",
+    recipe = {
+        {"ehlphabet:78_sticker", "ehlphabet:79_sticker", "ehlphabet:82_sticker"},
+        {"ehlphabet:84_sticker", "ehlphabet:72_sticker", ""},
+        {"", "", ""},
+    }
+})
+
+minetest.register_craft({
+    output = "ehlphabet:228184_sticker 5",
+    recipe = {
+        {"ehlphabet:69_sticker", "ehlphabet:65_sticker", "ehlphabet:83_sticker"},
+        {"ehlphabet:84_sticker", "", "ehlphabet:83_sticker"},
+        {"", "", ""},
+    }
+})
+
+minetest.register_craft({
+    output = "ehlphabet:230157_sticker 5",
+    recipe = {
+        {"ehlphabet:69_sticker", "ehlphabet:65_sticker", "ehlphabet:83_sticker"},
+        {"ehlphabet:84_sticker", "", "ehlphabet:84_sticker"},
+        {"", "", ""},
+    }
+})
+
+minetest.register_craft({
+    output = "ehlphabet:229141_sticker 5",
+    recipe = {
+        {"ehlphabet:83_sticker", "ehlphabet:79_sticker", "ehlphabet:85_sticker"},
+        {"ehlphabet:84_sticker", "ehlphabet:72_sticker", ""},
+        {"", "", ""},
+    }
+})
+
+minetest.register_craft({
+    output = "ehlphabet:232165_sticker 4",
+    recipe = {
+        {"ehlphabet:87_sticker", "ehlphabet:69_sticker", "ehlphabet:83_sticker"},
+        {"ehlphabet:84_sticker", "", ""},
+        {"", "", ""},
+    }
+})
+
+minetest.register_craft({
+    output = "ehlphabet:231171_sticker 7",
+    recipe = {
+        {"ehlphabet:83_sticker", "ehlphabet:84_sticker", "ehlphabet:65_sticker"},
+        {"ehlphabet:84_sticker", "ehlphabet:73_sticker", "ehlphabet:79_sticker"},
+        {"ehlphabet:78_sticker", "", ""},
+    }
+})

--- a/ehlphabet.lua
+++ b/ehlphabet.lua
@@ -1,4 +1,3 @@
-if not minetest.get_modpath('ehlphabet') then return end
 
 -- stickers of mandarin characters
 minetest.register_craft({

--- a/init.lua
+++ b/init.lua
@@ -164,6 +164,9 @@ dofile(MP.."/recipes.lua")
 -- craft overrides
 dofile(MP.."/crafts.lua")
 
+-- ehlphabet stickers
+dofile(MP.."/ehlphabet.lua")
+
 -- general hacks
 dofile(MP.."/hacks.lua")
 

--- a/init.lua
+++ b/init.lua
@@ -165,7 +165,9 @@ dofile(MP.."/recipes.lua")
 dofile(MP.."/crafts.lua")
 
 -- ehlphabet stickers
-dofile(MP.."/ehlphabet.lua")
+if minetest.get_modpath("ehlphabet") then
+	dofile(MP.."/ehlphabet.lua")
+end
 
 -- general hacks
 dofile(MP.."/hacks.lua")


### PR DESCRIPTION
adds missing recipes for mandarin stickers

I'm not sure we really need this though.
Arguably we could also move the recipe override into this file too (from crafts.lua)