### PR TITLE
Add additional stealthnodes: copperblock, goldblock, blast_resistant_concrete

### DIFF
--- a/mesecons_stealthnodes.lua
+++ b/mesecons_stealthnodes.lua
@@ -1,8 +1,11 @@
 
 local nodes = {
+    {"default", "copperblock"},
+    {"default", "goldblock"},
     {"scifi_nodes", "white"},
-    {"technic", "zinc_block"},
-    {"technic", "chromium_block"}
+    {"technic", "blast_resistant_concrete"},
+    {"technic", "chromium_block"},
+    {"technic", "zinc_block"}
 }
 
 for _,value in pairs(nodes) do


### PR DESCRIPTION
Add additional stealthnodes: `copperblock`, `goldblock`, `blast_resistant_concrete`.

Also sorted pandorabox custom nodes alphabetically (Lua doesn't care, but its orderly when skimming the list now).

"blast_resisant_concrete stealth node" was requested on EdenLost.  EdenLost uses the `pandorabox_custom` mod (for better or worse), so I figured that I'd try to add them for both servers.  If not, I can make a custom mod for EdenLost.