### PR TITLE
Hide beehive centrifuging recipes but add example

### DIFF
--- a/mobs_bees.lua
+++ b/mobs_bees.lua
@@ -42,6 +42,15 @@ for i = 1, 12 do
 	technic.register_separating_recipe({
 		input = {"mobs:beehive_" .. i .. " 1"},
 		output = {"mobs:beehive", "mobs:honey " .. i},
-		time = ( i + 2 ) * 3 - i
+		time = ( i + 2 ) * 3 - i,
+		hidden = true,
 	})
 end
+
+-- show example recipe in unified inventory
+unified_inventory.register_craft({
+	type = "separating",
+	items = {"mobs:beehive 1"},
+	output = "mobs:honey 1",
+	width = 0,
+})


### PR DESCRIPTION
To be merged after https://github.com/mt-mods/technic/pull/311

Hides the 12 different variations of the beehive centrifuging recipes, but also adds an example recipe to show in the craft guide.