### PR TITLE
Add mob drops to craft guide

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -182,6 +182,9 @@ end
 
 if minetest.get_modpath("mobs") then
 	dofile(MP .. "/mobs.lua")
+	if minetest.get_modpath("unified_inventory") then
+		dofile(MP .. "/mob_drops.lua")
+	end
 end
 
 if minetest.get_modpath("mobs_animal") then

--- a/mob_drops.lua
+++ b/mob_drops.lua
@@ -19,12 +19,14 @@ local function add_drop_recipes(name)
 		return
 	end
 	for _,drop in pairs(mob.drops) do
-		unified_inventory.register_craft({
-			type = drop.min > 0 and "mob_drop" or "mob_drop_player",
-			output = drop.name,
-			items = {name},
-			width = 0,
-		})
+		if minetest.registered_items[drop.name] then
+			unified_inventory.register_craft({
+				type = drop.min > 0 and "mob_drop" or "mob_drop_player",
+				output = drop.name,
+				items = {name},
+				width = 0,
+			})
+		end
 	end
 end
 

--- a/mob_drops.lua
+++ b/mob_drops.lua
@@ -1,0 +1,37 @@
+
+unified_inventory.register_craft_type("mob_drop", {
+	description = "Drops",
+	icon = "default_tool_steelsword.png",
+	width = 1,
+	height = 1,
+})
+
+unified_inventory.register_craft_type("mob_drop_player", {
+	description = "Drops (killed by player)",
+	icon = "default_tool_mesesword.png",
+	width = 1,
+	height = 1,
+})
+
+local function add_drop_recipes(name)
+	local mob = minetest.registered_entities[name]
+	if not mob or type(mob.drops) ~= "table" then
+		return
+	end
+	for _,drop in pairs(mob.drops) do
+		unified_inventory.register_craft({
+			type = drop.min > 0 and "mob_drop" or "mob_drop_player",
+			output = drop.name,
+			items = {name},
+			width = 0,
+		})
+	end
+end
+
+minetest.register_on_mods_loaded(function()
+	for name, def in pairs(minetest.registered_craftitems) do
+		if def.groups and def.groups.spawn_egg == 1 then
+			add_drop_recipes(name)
+		end
+	end
+end)


### PR DESCRIPTION
Adds mob drops to `unified_inventory`. Uses two types of "recipe" to distinguish between drops that require the mob to be killed by a player, and those that don't.

Examples:
![image](https://github.com/pandorabox-io/pandorabox_custom/assets/48543043/b93ff2eb-fc93-469a-807b-153a07b05928)
![image](https://github.com/pandorabox-io/pandorabox_custom/assets/48543043/c12d9006-5566-475a-9cbd-031082c895d3)
 