### PR TITLE
Mars is spelled with capital 'M'

### DIFF
--- a/privs/layers.lua
+++ b/privs/layers.lua
@@ -12,7 +12,7 @@ minetest.register_privilege("asteroids_access", {
 })
 
 minetest.register_privilege("mars_access", {
-	description = "Can travel to the mars",
+	description = "Can travel to Mars",
 	otp_keep = true
 })
 

--- a/travel/travel.lua
+++ b/travel/travel.lua
@@ -22,7 +22,7 @@ pandorabox.can_travel = function(player, pos)
 
 	-- mars
 	if pos.y > 10000 and pos.y < 17000 and not minetest.check_player_privs(player, "mars_access") then
-		return false, "You need the 'mars_access' priv to go to the mars!"
+		return false, "You need the 'mars_access' priv to go to Mars!"
 	end
 
 	-- warzone


### PR DESCRIPTION
also it is not preceeded with 'the'.
Same would apply to Earth, Saturn, etc.
But not 'the moon', 'the asteroids'.
There are various known moons, asteroids, suns/stars -> preceeded with 'the' and lower-case.
There is only one Earth, Saturn, Pluto etc. -> no 'the' and capitalized.