### PR TITLE
close offline player loophole

### DIFF
--- a/travel/jumpdrive.lua
+++ b/travel/jumpdrive.lua
@@ -21,13 +21,9 @@ jumpdrive.preflight_check = function(source, destination, radius, playername)
 		return { success=false, message="Atmospheric travel not allowed!" }
 	end
 
-	local player = minetest.get_player_by_name(playername)
-	if player then
-		-- player is online, check limits (non-automatic jump)
-		local can_teleport, err_msg = pandorabox.can_teleport(player, destination)
-		if not can_teleport then
-			return { success=false, message="Jump failed: " .. (err_msg or "") }
-		end
+	local can_teleport, err_msg = pandorabox.can_teleport(playername, destination)
+	if not can_teleport then
+		return { success=false, message="Jump failed: " .. (err_msg or "") }
 	end
 
 	-- everything ok


### PR DESCRIPTION
It seems like this code is a leftover from when JDs didn't have digilines yet and the ``player`` was the one interacting with the formspec. Now the ``player`` is the ``owner`` of the JD.

Also back then ``can_travel()`` was inspecting XP instead of privs. XP is stored in player meta, so isn't checkable when player is offline.

With this change, players can't jump over warzone or other places they normally couldn't go to (except landing-priv area). They used an alt to place the JD then while the alt wasn't online, the checks were skipped and by trapping the
online player in a chair(/bike/minecart/...) the
teleport_back globalstep couldn't force them
back to /spawn.