### PR TITLE
Update tp_tube_fixer.lua

### DIFF
--- a/tp_tube_fixer.lua
+++ b/tp_tube_fixer.lua
@@ -24,7 +24,7 @@ minetest.register_lbm({
 			local meta = minetest.get_meta(pos)
 			local channel = meta:get_string("channel")
 			if "" == channel then return end
-			
+
 			local can_receive = meta:get_int("can_receive")
 			db[hash] = { x = pos.x, y = pos.y, z = pos.z, channel = channel, cr = can_receive }
 			pipeworks.tptube.save_tube(hash)

--- a/tp_tube_fixer.lua
+++ b/tp_tube_fixer.lua
@@ -23,9 +23,12 @@ minetest.register_lbm({
 		if not db[hash] then
 			local meta = minetest.get_meta(pos)
 			local channel = meta:get_string("channel")
+			if "" == channel then return end
+			
 			local can_receive = meta:get_int("can_receive")
-			db[hash] = {x=pos.x, y=pos.y, z=pos.z, channel=channel, cr=can_receive}
-			pipeworks.tptube.save_tube_db()
+			db[hash] = { x = pos.x, y = pos.y, z = pos.z, channel = channel, cr = can_receive }
+			pipeworks.tptube.save_tube(hash)
+			pipeworks.tptube.update_meta(meta) -- not passing can_receive intentionally
 		end
 	end
 })


### PR DESCRIPTION
There were lag issues with saving the entire db on every tube found. Also unconfigured tubes aren't in db and don't need to be.

This PR:
- skips tubes without channels
- uses save_tube() instead of save_tube_db()
- also updates infotext by calling update_meta()